### PR TITLE
fix: ensure webview becomes tranparent with another fallback

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -77,6 +77,10 @@ public class CapacitorGoogleMaps: CustomMapViewEvents {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.setupWebView()
             }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.setupWebView()
+            }
         }
     }
     


### PR DESCRIPTION
Dirty fix because #238 does not entirely fix the issue. Might have something to do with internet speed