### PR TITLE
fix: resolve false positives with `isPixelTransparent` helper

### DIFF
--- a/ios/Sources/CapacitorGoogleMaps/Utilities/UIView+isPixelTransparent.swift
+++ b/ios/Sources/CapacitorGoogleMaps/Utilities/UIView+isPixelTransparent.swift
@@ -2,6 +2,32 @@ import UIKit
 
 extension UIView {
     func isPixelTransparent(at point: CGPoint) -> Bool {
+        var pixel: [UInt8] = [0, 0, 0, 0]
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+        guard let context = CGContext(
+            data: &pixel,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return false
+        }
+        
+        /**
+         * We could now do as follows:
+         * ```
+         * context.translateBy(x: -point.x, y: -point.y)
+         * self.layer.render(in: context)
+         * ```
+         * However, it seems that that approach doesn't work on some Metal-backed devices.
+         * So instead, we do it like the code below
+         */
+
         let scale = window?.screen.scale ?? contentScaleFactor
         let rect = CGRect(x: floor(point.x), y: floor(point.y), width: 1/scale, height: 1/scale)
 
@@ -12,10 +38,13 @@ extension UIView {
         let img = UIGraphicsImageRenderer(bounds: rect, format: format).image { _ in
             drawHierarchy(in: bounds, afterScreenUpdates: false)
         }
-        guard let cg = img.cgImage,
-              let data = cg.dataProvider?.data,
-              let bytes = CFDataGetBytePtr(data) else { return false }
 
-        return bytes[0] == 0 && bytes[1] == 0 && bytes[2] == 0 && bytes[3] == 0
+        guard let cgImage = img.cgImage else {
+            return false
+        }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+
+        return pixel[3] == 0
     }
 }


### PR DESCRIPTION
We changed this logic in https://github.com/capacitor-community/google-maps/pull/245 to workaround a specific bug for  Metal-backed views. However, it returns false positives. For example a black pixel is also seen as transparent, because the all four (checked) bytes are `0`.

This PR actually combines the two approaches into a combined more foolproof approach. It uses the snapshot approach to capture the pixel, but it uses the old approach of parsing it into a pixel array.